### PR TITLE
Added support for the Globus preview environment in v0.13.

### DIFF
--- a/client/oauth_ssh/constants.py
+++ b/client/oauth_ssh/constants.py
@@ -14,6 +14,10 @@ SETTINGS = {
                       '892ee39b-545a-4505-965a-cff0c96f4e74',
                       'auth.globus.org'
                   ),
+    'preview': (
+                      '12e557e7-ae78-4d2b-b05b-cc1b088ce27b',
+                      'auth.preview.globus.org'
+                  ),
     'sandbox':    (
                       'b15c619c-e40e-461a-9a43-0fa21e0f3d35',
                       'auth.sandbox.globuscs.info'

--- a/client/setup.py
+++ b/client/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='oauth_ssh',
-    version='0.12',
+    version='0.13',
     description='SSH with OAuth Tokens',
     long_description=open("README.rst").read(),
     url='https://github.com/xsede/oauth-ssh',


### PR DESCRIPTION
Small change which adds support for the Globus  preview environment to the oauth ssh client and bumps the version to 0.13.